### PR TITLE
Fix passport strategy cleanup

### DIFF
--- a/server/minimal-oauth.ts
+++ b/server/minimal-oauth.ts
@@ -53,8 +53,8 @@ export function initializeMinimalOAuth() {
   console.log('🔐 Has Client Secret:', !!process.env.GOOGLE_CLIENT_SECRET);
 
   // Clear existing strategies but preserve session support
-  if (passport._strategies.google) {
-    delete passport._strategies.google;
+  if (passport._strategy('google')) {
+    passport.unuse('google');
   }
   
   // Clear existing serializers/deserializers


### PR DESCRIPTION
## Summary
- cleanly unuse the google passport strategy in minimal OAuth setup

## Testing
- `npm run check` *(fails: exportDemo.ts errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b0578480c8327b5f44c835179a799