### PR TITLE
Integrate AI helpers with fallback

### DIFF
--- a/server/aiHelpers.ts
+++ b/server/aiHelpers.ts
@@ -1,0 +1,48 @@
+import { Configuration, OpenAIApi } from 'openai';
+
+export async function analyzeWithOpenAI(prompt: string): Promise<string> {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('Missing OPENAI_API_KEY');
+  }
+  const config = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+  const openai = new OpenAIApi(config);
+  const completion = await openai.createChatCompletion({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }]
+  });
+  return completion.data.choices[0]?.message?.content?.trim() || '';
+}
+
+export async function analyzeWithClaude(prompt: string): Promise<string> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('Missing ANTHROPIC_API_KEY');
+  }
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': process.env.ANTHROPIC_API_KEY,
+      'anthropic-version': '2023-06-01'
+    },
+    body: JSON.stringify({ model: 'claude-3-haiku-20240307', max_tokens: 1024, messages: [{ role: 'user', content: prompt }] })
+  });
+  if (!response.ok) {
+    throw new Error(`Claude API error: ${await response.text()}`);
+  }
+  const data = await response.json();
+  return data?.content?.[0]?.text?.trim() || '';
+}
+
+export async function analyzeText(prompt: string): Promise<string> {
+  try {
+    return await analyzeWithOpenAI(prompt);
+  } catch (error) {
+    console.error('OpenAI failed:', error);
+    try {
+      return await analyzeWithClaude(prompt);
+    } catch (fallbackError) {
+      console.error('Claude fallback failed:', fallbackError);
+      throw error;
+    }
+  }
+}

--- a/server/clientRoutes.ts
+++ b/server/clientRoutes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { storage } from './storage';
+import { analyzeText } from './aiHelpers';
 import { 
   insertClientSchema, 
   insertSessionNoteSchema,
@@ -260,9 +261,6 @@ function determineMaterialType(mimetype: string): string {
 }
 
 async function generateAIConceptualization(client: any, sessionNotes: any[], materials: any[]) {
-  // This would integrate with OpenAI API to generate case conceptualization
-  // For now, return a structured response
-  
   const allText = [
     client.notes || '',
     ...sessionNotes.map(note => [
@@ -274,27 +272,18 @@ async function generateAIConceptualization(client: any, sessionNotes: any[], mat
     ...materials.map(material => material.contentText || '')
   ].join('\n\n');
 
-  // This would call OpenAI API with the collected text
-  // const aiResponse = await openai.chat.completions.create({...})
-  
-  // Mock response for now
+  const prompt = `Generate a concise case conceptualization for the following client data:\n\n${allText}`;
+  let summary = '';
+  try {
+    summary = await analyzeText(prompt);
+  } catch (err) {
+    console.error('AI analysis failed:', err);
+  }
+
   return {
     conceptualizationData: {
-      clientProfile: `Comprehensive case analysis for ${client.name}`,
-      keyThemes: ['Progress tracking', 'Goal setting', 'Risk management'],
-      treatmentApproach: 'Evidence-based intervention strategies'
-    },
-    presentingProblems: ['Primary concern area', 'Secondary issues'],
-    treatmentGoals: ['Short-term objectives', 'Long-term outcomes'],
-    interventionsUsed: ['CBT techniques', 'Behavioral strategies'],
-    progressIndicators: {
-      improvementAreas: ['Communication', 'Coping skills'],
-      challengeAreas: ['Consistency', 'Follow-through']
-    },
-    riskFactors: [],
-    strengths: ['Client engagement', 'Family support'],
-    recommendations: ['Continue current approach', 'Consider group therapy'],
-    confidenceScore: 0.85
+      clientProfile: summary || `Case analysis for ${client.name}`
+    }
   };
 }
 


### PR DESCRIPTION
## Summary
- add AI helpers for OpenAI and Claude
- use new helper when generating AI conceptualizations

## Testing
- `npm run build`
- `npm run check` *(fails: TS6305 output file errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b12289ad483279e59a4be9de8073c